### PR TITLE
Disable batching of RPC calls. This was causing Promise (of PromiseKit) instances to be retained unnecessarily when there are many (1000s of) web3 calls

### DIFF
--- a/web3swift/Web3/Classes/Web3+Instance.swift
+++ b/web3swift/Web3/Classes/Web3+Instance.swift
@@ -42,7 +42,7 @@ public class web3: Web3OptionsInheritable {
             self.dispatcher = dispatcher!
         }
         if requestDispatcher == nil {
-            self.requestDispatcher = JSONRPCrequestDispatcher(provider: provider, queue: self.queue.underlyingQueue!, policy: .Batch(32))
+            self.requestDispatcher = JSONRPCrequestDispatcher(provider: provider, queue: self.queue.underlyingQueue!, policy: .NoBatching)
         } else {
             self.requestDispatcher = requestDispatcher!
         }


### PR DESCRIPTION
Found while looking at https://github.com/AlphaWallet/alpha-wallet-ios/issues/1652.

There are 2 issues with this:

A. Calls don't get batched in practice. They are always in a batch of 1. Looks like a bug
B. The batching code causes `Promise` instances to be retained. This is bad once we start making many (1000s) of web3 calls over the app's entire life cycle

Ran out of time hunting 1652 down and can't fix (A), so disabling it for now.