### PR TITLE
Attempt to fix crash when accessing Dictionary.subscript.getter

### DIFF
--- a/web3swift/Promises/Classes/Promise+Batching.swift
+++ b/web3swift/Promises/Classes/Promise+Batching.swift
@@ -46,7 +46,7 @@ public class JSONRPCrequestDispatcher {
             }
             let requestID = request.id
             let promiseToReturn = Promise<JSONRPCresponse>.pending()
-            self.queue.async {
+            self.lockQueue.async {
                 if self.promisesDict[requestID] != nil {
                     promiseToReturn.resolver.reject(Web3Error.processingError("Request ID collision"))
                 }


### PR DESCRIPTION
From Xcode crash logs, hard to tell the true cause though.